### PR TITLE
Add data_units_read/written and model_number

### DIFF
--- a/source/app/prometheus_smartctl_exporter
+++ b/source/app/prometheus_smartctl_exporter
@@ -129,6 +129,8 @@ parse_smartctl_nvme_attributes() {
     Available_Spare) available_spare="$(echo ${attr_value} | awk '{ printf "%d\n", $1 }')" ;;
     Available_Spare_Threshold) available_spare_threshold="$(echo ${attr_value} | awk '{ printf "%d\n", $1 }')" ;;
     Media_and_Data_Integrity_Errors) media_and_data_integrity_errors="$(echo ${attr_value} | awk '{ printf "%d\n", $1 }')" ;;
+    Data_Units_Read) data_units_read=$(echo $attr_value | cut -f1 -d" " | tr -dc "0-9" | awk '{ printf "%d\n", $1 }') ;;
+    Data_Units_Written) data_units_written=$(echo $attr_value | cut -f1 -d" " | tr -dc "0-9" | awk '{ printf "%d\n", $1 }') ;;
     esac
   done
 
@@ -146,6 +148,8 @@ parse_smartctl_nvme_attributes() {
   [ ! -z "$available_spare" ] && echo "available_spare_raw_value{${labels},smart_id=\"255\"} ${available_spare}"
   [ ! -z "$available_spare_threshold" ] && echo "available_spare_threshold{${labels},smart_id=\"255\"} ${available_spare_threshold}"
   [ ! -z "$media_and_data_integrity_errors" ] && echo "media_and_data_integrity_errors_count_raw_value{${labels},smart_id=\"255\"} ${media_and_data_integrity_errors}"
+  [ ! -z "$data_units_read" ] && echo "data_units_read_raw_value{${labels},smart_id=\"255\"} ${data_units_read}"
+  [ ! -z "$data_units_written" ] && echo "data_units_written_raw_value{${labels},smart_id=\"255\"} ${data_units_written}"
 }
 
 parse_smartctl_info() {
@@ -157,6 +161,7 @@ parse_smartctl_info() {
     info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^ \+//g' | sed 's/"/\\"/')"
     case "${info_type}" in
     Model_Family) model_family="${info_value}" ;;
+    Model_Number) model_number="${info_value}" ;;
     Device_Model) device_model="${info_value}" ;;
     Serial_Number) serial_number="${info_value}" ;;
     Firmware_Version) fw_version="${info_value}" ;;
@@ -182,7 +187,7 @@ parse_smartctl_info() {
       esac
     fi
   done
-  echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",vendor=\"${vendor}\",product=\"${product}\",revision=\"${revision}\",lun_id=\"${lun_id}\",model_family=\"${model_family}\",device_model=\"${device_model}\",serial_number=\"${serial_number}\",firmware_version=\"${fw_version}\"} 1"
+  echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",vendor=\"${vendor}\",product=\"${product}\",revision=\"${revision}\",lun_id=\"${lun_id}\",model_family=\"${model_family}\",model_number=\"${model_number}\",device_model=\"${device_model}\",serial_number=\"${serial_number}\",firmware_version=\"${fw_version}\"} 1"
   echo "device_smart_available{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_available}"
   echo "device_smart_enabled{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_enabled}"
   echo "device_smart_healthy{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_healthy}"


### PR DESCRIPTION
Hey @ich777, first of all thank you for all the generous and awesome work you did for Unraid!

I've been using telegraf and InfluxDB for a long time to monitor my Unraid system but recently tried to migrate to Prometheus. While trying to replicate my SSD/NVMe graphs I found this exporter to add S.M.A.R.T. data to the simple node exporter metrics.

I quickly realized that not all necessary NVMe information is exported. This PR adds two new metrics and extends the device_info.

## new metrics

`data_units_written` can be used to calculate unified "Total Bytes Written" graphs for SSDs and NVMes.
`data_units_read` was only added because it seemed reasonable to also include it…

Parsing those is a bit of a headache because the output looks like this:

Data Units Read:                    4,516,720 [2.31 TB]
Data Units Written:                 21,595,328 [11.0 TB]

I decided to just burn everything after the first space and use the tr+awk combination to clean the number as used in other parts already.

## device_info

`model_number` is equivalent to `model_family` for my NVMe drive, a quick google search seems to suggest that this is the same for all of them. Regardless, this shouldn't break anything, only add an empty label for non-NVMe drives.