### PR TITLE
Fix a error in the Node exporter settings check

### DIFF
--- a/prometheus_smartctl_exporter.plg
+++ b/prometheus_smartctl_exporter.plg
@@ -70,8 +70,8 @@ fi
 
 # Check if settings file for Prometheus Node Export is already patched
 NODE_SETTINGS="$(cat /boot/config/plugins/prometheus_node_exporter/settings.cfg | cut -d '=' -f2-)"
-if [ ! "$(echo ${NODE_SETTINGS} | grep "collector.textfile.director")" ]; then
-  if [ -z "${NODES_SETTINGS}" ]; then
+if [[ ! $(echo ${NODE_SETTINGS} | grep "collector.textfile.director") ]]; then
+  if [ -z ${NODE_SETTINGS} ]; then
     sed -i 's/start_parameters=/start_parameters=--collector.textfile.directory=\/tmp\/prom_export/g' /boot/config/plugins/prometheus_node_exporter/settings.cfg
   else 
     sed -i 's/$/ \-\-collector.textfile.directory=\/tmp\/prom_export/' /boot/config/plugins/prometheus_node_exporter/settings.cfg


### PR DESCRIPTION
There is a spelling error in the nested if conditional. Fixed that also I cleaned up the bash syntax a bit since.