### PR TITLE
Fix startup problem Unraid 7.2.0

### DIFF
--- a/prometheus_smartctl_exporter.plg
+++ b/prometheus_smartctl_exporter.plg
@@ -86,7 +86,7 @@ fi
 
 # Start Exporter
 
-if [ ! -z "$(ps -fu root | grep "smartctl_exporter.sh" | grep -v "grep" | awk '{print $2}')" ]; then
+if [ ! -z "$(pgrep --ns $$ -f "&emhttp;/smartctl_exporter.sh")" ]; then
   echo "---Prometheus smartctl Exporter already started!---"
 else
   echo "---Starting Prometheus smartctl Exporter---"
@@ -104,7 +104,7 @@ echo "-----------------------------------------------"
 echo "---Uninstalling prometheus_smartctl_exporter---"
 echo "-----------------------------------------------"
 # Remove plugin related files
-kill $(ps -fu root | grep "smartctl_exporter.sh" | grep -v "grep" | awk '{print $2}')
+kill $(pgrep --ns $$ -f "&emhttp;/smartctl_exporter.sh") 2>/dev/null
 sed -i 's/--collector.textfile.directory=\/tmp\/prom_export//g' /boot/config/plugins/prometheus_node_exporter/settings.cfg
 removepkg &name;-&version;
 rm -rf /usr/local/emhttp/plugins/&name;


### PR DESCRIPTION
Plugin does not work on Unraid 7.2.0 because now Unraid seems to start a 
"/bin/bash /tmp/inline4-prometheus_smartctl_exporter.sh" process when installing the plugin.
This make the ps + grep cmd  thinking "smartctl_exporter.sh" is started, we need to fix this by adding the full cmd to grep